### PR TITLE
feat: handle fs event and resolve content in node

### DIFF
--- a/packages/collaboration/__tests__/browser/collaboration-contribution.test.ts
+++ b/packages/collaboration/__tests__/browser/collaboration-contribution.test.ts
@@ -2,7 +2,7 @@ import { KeybindingRegistry, KeybindingWeight, PreferenceService } from '@opensu
 import { CommandRegistry, CommandRegistryImpl, IDisposable, ILogger } from '@opensumi/ide-core-common';
 import { createBrowserInjector } from '@opensumi/ide-dev-tool/src/injector-helper';
 import { MockInjector } from '@opensumi/ide-dev-tool/src/mock-injector';
-import { IFileServiceClient } from '@opensumi/ide-file-service';
+import { IFileService, IFileServiceClient } from '@opensumi/ide-file-service';
 
 import { CollaborationServiceForClientPath, ICollaborationService, IYWebsocketServer } from '../../src';
 import { CollaborationContribution } from '../../src/browser/collaboration.contribution';
@@ -22,6 +22,7 @@ describe('CollaborationContribution test', () => {
     injector.mockService(ILogger);
     injector.mockService(PreferenceService);
     injector.mockService(IFileServiceClient);
+    injector.mockService(IFileService);
     injector.mockService(KeybindingRegistry);
     injector.addProviders(
       CollaborationContribution,

--- a/packages/collaboration/src/browser/collaboration.service.ts
+++ b/packages/collaboration/src/browser/collaboration.service.ts
@@ -3,8 +3,7 @@ import { WebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';
 
 import { Injectable, Autowired, Inject, INJECTOR_TOKEN, Injector } from '@opensumi/di';
-import { FilesChangeEvent } from '@opensumi/ide-core-browser';
-import { FileChangeType, ILogger, OnEvent, WithEventBus } from '@opensumi/ide-core-common';
+import { ILogger, OnEvent, WithEventBus } from '@opensumi/ide-core-common';
 import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { EditorActiveResourceStateChangedEvent, EditorGroupCloseEvent } from '@opensumi/ide-editor/lib/browser';
 import { WorkbenchEditorServiceImpl } from '@opensumi/ide-editor/lib/browser/workbench-editor.service';
@@ -137,16 +136,6 @@ export class CollaborationService extends WithEventBus implements ICollaboration
     }
   }
 
-  @OnEvent(FilesChangeEvent)
-  private fileChangeEventHandler(e: FilesChangeEvent) {
-    e.payload.forEach((e) => {
-      if (e.type === FileChangeType.DELETED) {
-        this.logger.debug('DELETED', e.uri);
-        this.backService.removeYText(e.uri);
-      }
-    });
-  }
-
   @OnEvent(EditorGroupCloseEvent)
   private groupCloseHandler(e: EditorGroupCloseEvent) {
     this.logger.debug('Group close tabs', e);
@@ -189,8 +178,10 @@ export class CollaborationService extends WithEventBus implements ICollaboration
         this.logger.debug('Binding created', binding);
       } else {
         // tell server to set init content
-        this.backService.setInitContent(uri, text);
+        this.backService.requestInitContent(uri);
         // binding will be eventually created on yMap event
+
+        // FIXME if file not found?
         this.pendingBinding.set(uri, { model: textModel, editor: monacoEditor });
       }
     } else {

--- a/packages/collaboration/src/common/index.ts
+++ b/packages/collaboration/src/common/index.ts
@@ -21,7 +21,7 @@ export const ICollaborationServiceForClient = Symbol('ICollaborationServiceForCl
 
 export interface ICollaborationServiceForClient {
   removeYText(uri: string): void;
-  setInitContent(uri: string, initContent: string): void;
+  requestInitContent(uri: string): Promise<void>;
 }
 
 export const ROOM_NAME = 'y-room-opensumi';


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features
- [x] 🐛 Bug Fixes

### Background or solution

如果让前端来进行初始化的话，初始化文本的值`initContent`是与`EditorDocumentModel`相关的，不一定是从文件系统读取出来的值（比如某一人删除了文件，但是其他人的前端还是打开着这个文件，这个时候，打开着这个文件的人，切换一下tab，就会触发初始化文本的操作）

### Changelog

- 将初始化文本的操作移到后端，直接从文件系统读取文本
- 在后端响应文件删除事件