### PR TITLE
Move out methods from backService class

### DIFF
--- a/packages/collaboration/__tests__/browser/collaboration-service.test.ts
+++ b/packages/collaboration/__tests__/browser/collaboration-service.test.ts
@@ -16,9 +16,9 @@ import { IFileService } from '@opensumi/ide-file-service';
 import { ITextModel } from '@opensumi/ide-monaco';
 import * as monaco from '@opensumi/monaco-editor-core/esm/vs/editor/editor.api';
 
-import { CollaborationServiceForClientPath, ICollaborationService, IYWebsocketServer } from '../../src';
 import { CollaborationService } from '../../src/browser/collaboration.service';
 import { TextModelBinding } from '../../src/browser/textmodel-binding';
+import { CollaborationServiceForClientPath, ICollaborationService, IYWebsocketServer } from '../../src/common';
 import { CollaborationServiceForClient } from '../../src/node/collaboration.service';
 import { YWebsocketServerImpl } from '../../src/node/y-websocket-server';
 
@@ -96,15 +96,14 @@ describe('CollaborationService basic routines', () => {
       useClass: MockDocModelService,
     });
 
-    server = injector.get(YWebsocketServerImpl);
+    server = injector.get(IYWebsocketServer);
     eventBus = injector.get(IEventBus);
     service = injector.get(ICollaborationService);
 
     // mock impl, because origin impl comes with nodejs
-    const serviceForClient: CollaborationServiceForClient = injector.get(CollaborationServiceForClientPath);
-    jest.spyOn(serviceForClient, 'requestInitContent').mockImplementation(async (uri: string) => {
-      if (!serviceForClient['yMap'].has(uri)) {
-        serviceForClient['yMap'].set(uri, new Y.Text('init content'));
+    jest.spyOn(server, 'requestInitContent').mockImplementation(async (uri: string) => {
+      if (!server['yMap'].has(uri)) {
+        server['yMap'].set(uri, new Y.Text('init content'));
       }
     });
 

--- a/packages/collaboration/__tests__/browser/collaboration-service.test.ts
+++ b/packages/collaboration/__tests__/browser/collaboration-service.test.ts
@@ -170,6 +170,6 @@ describe('CollaborationService basic routines', () => {
   });
 
   afterAll(() => {
-    server.dispose();
+    server.destroy();
   });
 });

--- a/packages/collaboration/__tests__/node/service.test.ts
+++ b/packages/collaboration/__tests__/node/service.test.ts
@@ -70,7 +70,7 @@ describe('Collaboration node ws server test', () => {
 
   it('should correctly dispose', () => {
     const spy = jest.spyOn(server, 'dispose');
-    server.dispose();
+    server.destroy();
     expect(spy).toBeCalled();
   });
 

--- a/packages/collaboration/__tests__/node/service.test.ts
+++ b/packages/collaboration/__tests__/node/service.test.ts
@@ -63,7 +63,7 @@ describe('Collaboration node ws server test', () => {
   });
 
   it('should remove Y.Text', () => {
-    service.removeYText(TEST_URI);
+    server.removeYText(TEST_URI);
     const yMap = yDoc.getMap();
     expect(yMap.has(TEST_URI)).toBeFalsy();
   });

--- a/packages/collaboration/__tests__/node/service.test.ts
+++ b/packages/collaboration/__tests__/node/service.test.ts
@@ -69,7 +69,7 @@ describe('Collaboration node ws server test', () => {
   });
 
   it('should correctly dispose', () => {
-    const spy = jest.spyOn(server, 'dispose');
+    const spy = jest.spyOn(server, 'destroy');
     server.destroy();
     expect(spy).toBeCalled();
   });

--- a/packages/collaboration/src/common/index.ts
+++ b/packages/collaboration/src/common/index.ts
@@ -17,6 +17,8 @@ export const IYWebsocketServer = Symbol('IYWebsocketServer');
 
 export interface IYWebsocketServer {
   getYDoc(room: string): Y.Doc;
+  removeYText(uri: string): void;
+  requestInitContent(uri: string): Promise<void>;
 }
 
 export const CollaborationServiceForClientPath = 'CollaborationServiceForClientPath';
@@ -24,7 +26,6 @@ export const CollaborationServiceForClientPath = 'CollaborationServiceForClientP
 export const ICollaborationServiceForClient = Symbol('ICollaborationServiceForClient');
 
 export interface ICollaborationServiceForClient {
-  removeYText(uri: string): void;
   requestInitContent(uri: string): Promise<void>;
 }
 

--- a/packages/collaboration/src/common/index.ts
+++ b/packages/collaboration/src/common/index.ts
@@ -16,8 +16,6 @@ export interface ICollaborationService {
 export const IYWebsocketServer = Symbol('IYWebsocketServer');
 
 export interface IYWebsocketServer {
-  getYDoc(room: string): Y.Doc;
-  removeYText(uri: string): void;
   requestInitContent(uri: string): Promise<void>;
 }
 

--- a/packages/collaboration/src/node/collaboration.contribution.ts
+++ b/packages/collaboration/src/node/collaboration.contribution.ts
@@ -18,6 +18,6 @@ export class CollaborationNodeContribution implements ServerAppContribution {
   }
 
   onStop() {
-    this.server.dispose();
+    this.server.destroy();
   }
 }

--- a/packages/collaboration/src/node/collaboration.service.ts
+++ b/packages/collaboration/src/node/collaboration.service.ts
@@ -1,11 +1,7 @@
-import * as Y from 'yjs';
-
 import { Autowired, Injectable } from '@opensumi/di';
 import { INodeLogger } from '@opensumi/ide-core-node';
-import { FileChangeType, IFileService } from '@opensumi/ide-file-service';
-import { FileService } from '@opensumi/ide-file-service/lib/node';
 
-import { ICollaborationServiceForClient, IYWebsocketServer, ROOM_NAME } from '../common';
+import { ICollaborationServiceForClient, IYWebsocketServer } from '../common';
 
 @Injectable()
 export class CollaborationServiceForClient implements ICollaborationServiceForClient {
@@ -15,63 +11,7 @@ export class CollaborationServiceForClient implements ICollaborationServiceForCl
   @Autowired(IYWebsocketServer)
   private server: IYWebsocketServer;
 
-  @Autowired(IFileService)
-  private fileService: FileService;
-
-  private yDoc: Y.Doc;
-
-  private yMap: Y.Map<Y.Text>;
-
-  constructor() {
-    // init
-    this.yDoc = this.server.getYDoc(ROOM_NAME);
-    this.yMap = this.yDoc.getMap();
-
-    this.yMap.observe((e) => {
-      e.changes.keys.forEach((change, key) => {
-        this.logger.debug(`[Collaboration] operation ${change.action} occurs on key ${key}`);
-      });
-    });
-
-    this.fileService.onFilesChanged((e) => {
-      e.changes
-        .filter((e) => e.type === FileChangeType.DELETED)
-        .forEach((e) => {
-          if (e.type === FileChangeType.DELETED) {
-            this.logger.debug('on file event deleted', e);
-            this.removeYText(e.uri);
-            this.logger.debug('removed Y.Text of', e.uri);
-          }
-        });
-
-      e.changes
-        .filter((e) => e.type === FileChangeType.ADDED)
-        .forEach((e) => {
-          this.logger.debug('on file event added', e);
-          this.requestInitContent(e.uri);
-        });
-    });
-  }
-
-  removeYText(uri: string) {
-    this.logger.debug('trying to remove uri', uri);
-    if (this.yMap.has(uri)) {
-      this.yMap.delete(uri);
-      this.logger.debug('removed', uri);
-    }
-  }
-
   async requestInitContent(uri: string): Promise<void> {
-    try {
-      // load content from disk, not client
-      const { content } = await this.fileService.resolveContent(uri);
-      this.logger.debug('resolved content', content.substring(0, 20), 'from', uri);
-      if (!this.yMap.has(uri)) {
-        const yText = new Y.Text(content); // create yText with initial content
-        this.yMap.set(uri, yText);
-      }
-    } catch (e) {
-      this.logger.error(e);
-    }
+    await this.server.requestInitContent(uri);
   }
 }

--- a/packages/collaboration/src/node/y-websocket-server.ts
+++ b/packages/collaboration/src/node/y-websocket-server.ts
@@ -104,7 +104,7 @@ export class YWebsocketServerImpl implements IYWebsocketServer {
     }
   }
 
-  dispose() {
+  destroy() {
     this.websocketServer.close();
     this.server.close();
   }

--- a/packages/collaboration/src/node/y-websocket-server.ts
+++ b/packages/collaboration/src/node/y-websocket-server.ts
@@ -6,13 +6,22 @@ import * as Y from 'yjs';
 
 import { Injectable, Autowired } from '@opensumi/di';
 import { INodeLogger } from '@opensumi/ide-core-node';
+import { FileChangeType, IFileService } from '@opensumi/ide-file-service';
+import { FileService } from '@opensumi/ide-file-service/lib/node';
 
-import { IYWebsocketServer } from '../common';
+import { IYWebsocketServer, ROOM_NAME } from '../common';
 
 @Injectable()
 export class YWebsocketServerImpl implements IYWebsocketServer {
   @Autowired(INodeLogger)
   private logger: INodeLogger;
+
+  @Autowired(IFileService)
+  private fileService: FileService;
+
+  private yDoc: Y.Doc;
+
+  private yMap: Y.Map<Y.Text>;
 
   private websocketServer: ws.Server;
 
@@ -42,6 +51,57 @@ export class YWebsocketServerImpl implements IYWebsocketServer {
     this.server.listen(12345, () => {
       this.logger.log('y-websocket server listening on port 12345');
     });
+
+    // init
+    this.yDoc = this.getYDoc(ROOM_NAME);
+    this.yMap = this.yDoc.getMap();
+
+    this.yMap.observe((e) => {
+      e.changes.keys.forEach((change, key) => {
+        this.logger.debug(`[Collaboration] operation ${change.action} occurs on key ${key}`);
+      });
+    });
+
+    this.fileService.onFilesChanged((e) => {
+      e.changes
+        .filter((e) => e.type === FileChangeType.DELETED)
+        .forEach((e) => {
+          if (e.type === FileChangeType.DELETED) {
+            this.logger.debug('on file event deleted', e);
+            this.removeYText(e.uri);
+            this.logger.debug('removed Y.Text of', e.uri);
+          }
+        });
+
+      e.changes
+        .filter((e) => e.type === FileChangeType.ADDED)
+        .forEach((e) => {
+          this.logger.debug('on file event added', e);
+          this.requestInitContent(e.uri);
+        });
+    });
+  }
+
+  removeYText(uri: string) {
+    this.logger.debug('trying to remove uri', uri);
+    if (this.yMap.has(uri)) {
+      this.yMap.delete(uri);
+      this.logger.debug('removed', uri);
+    }
+  }
+
+  async requestInitContent(uri: string): Promise<void> {
+    try {
+      // load content from disk, not client
+      const { content } = await this.fileService.resolveContent(uri);
+      this.logger.debug('resolved content', content.substring(0, 20), 'from', uri);
+      if (!this.yMap.has(uri)) {
+        const yText = new Y.Text(content); // create yText with initial content
+        this.yMap.set(uri, yText);
+      }
+    } catch (e) {
+      this.logger.error(e);
+    }
   }
 
   dispose() {


### PR DESCRIPTION
### Changelog

- Related listener and handler are moved from backService class to non-backService class.
- Removed methods from interface `IYWebsocketServer`
